### PR TITLE
bugfix: bash: handle bash unit tests

### DIFF
--- a/ctf/analysis/BashAnalysis.py
+++ b/ctf/analysis/BashAnalysis.py
@@ -21,6 +21,8 @@ class BashAnalysis(AbstractAnalysis):
 
     @staticmethod
     def can_analyse(filepath):
+        if re.match(r"^tests/unit/bash/\w+\.sh$", filepath):
+            return False
         if re.match(r"^(?!shared/).*/bash/\w+\.sh$", filepath):
             return True
         return False


### PR DESCRIPTION
Next regexp hits `tests/unit/bash/execute_tests.sh` and that is wrong.