### PR TITLE
Stop using deprecated find_module method

### DIFF
--- a/ctf/diff_analysis.py
+++ b/ctf/diff_analysis.py
@@ -37,8 +37,8 @@ def analyse_file(file_record):
     for importer, package_name, _ in pkgutil.iter_modules([path.dirname(__file__)
                                                            + "/analysis"]):
         full_package_name = "%s.%s" % ("ctf.analysis", package_name)
-        module = importer.find_module(full_package_name).load_module(
-            full_package_name)
+        spec = importer.find_spec(full_package_name)
+        module = spec.loader.load_module()
         analysis_modules.append(module)
 
     # Get all classes with "is_valid" method


### PR DESCRIPTION
This method has been removed in Python 3.12.

Addressing:
Traceback (most recent call last):
  File "/__w/content/content/./ctf/content_test_filtering.py", line 44, in <module>
    diff_structure = diff_analysis.analyse_file(file_record)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/content/content/ctf/ctf/diff_analysis.py", line 40, in analyse_file
    module = importer.find_module(full_package_name).load_module(
             ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FileFinder' object has no attribute 'find_module'