### PR TITLE
Adjust test scenarios to use more generic approach and use rpm_verify_* rules

### DIFF
--- a/tests/bash.bats
+++ b/tests/bash.bats
@@ -38,10 +38,10 @@ prepare_repository
 }
 
 @test "Change remediation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/chmod 600/chmod 744/" "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    sed -i "s/rpm//" "$file"
     regex_check_1="build_product "
-    regex_check_2="test_suite\.py rule.*sssd_run_as_sssd_user"
+    regex_check_2="test_suite\.py rule.*rpm_verify_permissions"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/jinja.bats
+++ b/tests/jinja.bats
@@ -8,9 +8,8 @@ prepare_repository
     file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
     regex_check_1="build_product"
-    regex_check_2="test_suite.py rule.*sshd_use_strong_macs"
-    regex_check_3="test_suite.py rule.*sshd_set_idle_timeout"
-    regex_check_4="test_suite.py rule.*sshd_use_priv_separation"
+    regex_check_2="test_suite.py rule.*sshd_set_"
+    regex_check_3="test_suite.py rule.*sshd_use_"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_bash.bats
+++ b/tests/json_bash.bats
@@ -38,9 +38,9 @@ prepare_repository
 }
 
 @test "Change remediation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/chmod 600/chmod 744/" "$file"
-    regex_check='{.*"rules": \["sssd_run_as_sssd_user"\].*"bash": "True".*"ansible": "False"}'
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    sed -i "s/rpm//" "$file"
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "False"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_jinja.bats
+++ b/tests/json_jinja.bats
@@ -7,10 +7,8 @@ prepare_repository
 @test "Change sshd macro" {
     file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
-    regex_check_1='{.*"rules": \[.*"sshd_use_strong_ciphers".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_2='{.*"rules": \[.*"sshd_use_strong_macs".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_3='{.*"rules": \[.*"sshd_set_keepalive".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_4='{.*"rules": \[.*"sshd_set_idle_timeout".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_1='{.*"rules": \[.*"sshd_use_.*".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_2='{.*"rules": \[.*"sshd_set_.*".*\].*"bash": "True".*"ansible": "False".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 


### PR DESCRIPTION
rpm_verify_* rules are not expected to be templated because of their specificity. Thus, use them as testing examples.