### PR TITLE
Change rule prodtype search and make tests more content change proof

### DIFF
--- a/ctf/DiffStruct.py
+++ b/ctf/DiffStruct.py
@@ -119,20 +119,17 @@ class DiffStruct:
         return profiles
 
     def get_rule_products(self, rule):
+        products = []
         # Parse from matched profiles product names
-        ruleyml_path = self.get_rule_ruleyml(rule)
-        prodtype_line = None
-        with open(ruleyml_path) as f:
-            for line in f.readlines():
-                if "prodtype:" in line:
-                    prodtype_line = line
-                    break
-        # rule.yml does not have prodtype
-        if not prodtype_line:
-            return None
+        for profile_path in self.find_rule_profiles(rule):
+            parse_file = re.match(r".+/((?:\w|-)+)/profiles/(?:\w|-)+\.profile",
+                                  profile_path)
+            products.append(parse_file.group(1))
+        # Find in controls and from controls get product
+        for control in self.find_rule_controls(rule):
+            for product in self.find_control_products(control):
+                products.append(product)
 
-        prodtypes = re.match(r"\s*prodtype:\s*([\w|,]+)\s*", prodtype_line).group(1)
-        products = prodtypes.split(",")
         products = sorted(products, key=lambda k: (k!="rhel8", k!="rhel7", k!="ocp4", k))
         return products
 

--- a/tests/ansible.bats
+++ b/tests/ansible.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment line" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     sed -i "\$a# comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -21,7 +21,7 @@ prepare_repository
 }
 
 @test "Change metadata" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     sed -i 's/# reboot = false/# reboot = true/' "$file"
     regex_check="build_product "
 
@@ -38,8 +38,8 @@ prepare_repository
 }
 
 @test "Change name" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
-    sed -i 's/- name: Disable.*/- name: some name/' "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
+    sed -i 's/- name: .*/- name: some name/' "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -54,10 +54,10 @@ prepare_repository
 }
 
 @test "Change remediation part" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
-    sed -i 's;path: .*;path: /some/path/;' "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
+    sed -i 's/command: .*/command: ls/' "$file"
     regex_check_1="build_product "
-    regex_check_2=".*test_suite\.py rule.*disable_prelink"
+    regex_check_2=".*test_suite\.py rule.*rpm_verify_permissions"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -98,7 +98,7 @@ prepare_repository
 }
 
 @test "Remove ansible remediation" {
-    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     rm -f "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/bash.bats
+++ b/tests/bash.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment line" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
     sed -i "\$a# comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -38,10 +38,10 @@ prepare_repository
 }
 
 @test "Change remediation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/chmod 600/chmod 744/" "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    sed -i "s/rpm//" "$file"
     regex_check_1="build_product "
-    regex_check_2="test_suite\.py rule.*sssd_run_as_sssd_user"
+    regex_check_2="test_suite\.py rule.*rpm_verify_permissions"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -83,7 +83,7 @@ prepare_repository
 
 
 @test "Remove bash remediation" {
-    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
     rm -f "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/jinja.bats
+++ b/tests/jinja.bats
@@ -8,9 +8,8 @@ prepare_repository
     file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
     regex_check_1="build_product"
-    regex_check_2="test_suite.py rule.*sshd_use_strong_macs"
-    regex_check_3="test_suite.py rule.*sshd_set_idle_timeout"
-    regex_check_4="test_suite.py rule.*sshd_use_priv_separation"
+    regex_check_2="test_suite.py rule.*sshd_set_"
+    regex_check_3="test_suite.py rule.*sshd_use_"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 

--- a/tests/json_ansible.bats
+++ b/tests/json_ansible.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment line" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     sed -i "\$a# comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -21,7 +21,7 @@ prepare_repository
 }
 
 @test "Change metadata" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     sed -i 's/# reboot = false/# reboot = true/' "$file"
     regex_check="build_product "
 
@@ -38,8 +38,8 @@ prepare_repository
 }
 
 @test "Change name" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
-    sed -i 's/- name: Disable.*/- name: some name/' "$file"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
+    sed -i 's/- name: .*/- name: some name/' "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -54,9 +54,9 @@ prepare_repository
 }
 
 @test "Change remediation part" {
-    file="./linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml"
-    sed -i 's;path: .*;path: /some/path/;' "$file"
-    regex_check='{.*"rules": \["disable_prelink"\].*"bash": "False".*"ansible": "True"}'
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
+    sed -i 's/command: .*/command: ls/' "$file"
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "False".*"ansible": "True"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -88,7 +88,7 @@ prepare_repository
 }
 
 @test "Remove ansible remediation" {
-    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml"
     rm -f "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/json_bash.bats
+++ b/tests/json_bash.bats
@@ -5,7 +5,7 @@ prepare_repository
 
 
 @test "Add comment line" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
     sed -i "\$a# comment" "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null
@@ -38,9 +38,9 @@ prepare_repository
 }
 
 @test "Change remediation" {
-    file="./linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh"
-    sed -i "s/chmod 600/chmod 744/" "$file"
-    regex_check='{.*"rules": \["sssd_run_as_sssd_user"\].*"bash": "True".*"ansible": "False"}'
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
+    sed -i "s/rpm//" "$file"
+    regex_check='{.*"rules": \["rpm_verify_permissions"\].*"bash": "True".*"ansible": "False"}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 
@@ -73,7 +73,7 @@ prepare_repository
 
 
 @test "Remove bash remediation" {
-    file="./linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh"
+    file="./linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh"
     rm -f "$file"
 
     git add "$file" && git commit -m "test commit" &>/dev/null

--- a/tests/json_jinja.bats
+++ b/tests/json_jinja.bats
@@ -7,10 +7,8 @@ prepare_repository
 @test "Change sshd macro" {
     file="./shared/macros/10-bash.jinja"
     sed -i "/macro bash_sshd_config_set/a echo 1" "$file"
-    regex_check_1='{.*"rules": \[.*"sshd_use_strong_ciphers".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_2='{.*"rules": \[.*"sshd_use_strong_macs".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_3='{.*"rules": \[.*"sshd_set_keepalive".*\].*"bash": "True".*"ansible": "False".*}'
-    regex_check_4='{.*"rules": \[.*"sshd_set_idle_timeout".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_1='{.*"rules": \[.*"sshd_use_.*".*\].*"bash": "True".*"ansible": "False".*}'
+    regex_check_2='{.*"rules": \[.*"sshd_set_.*".*\].*"bash": "True".*"ansible": "False".*}'
 
     git add "$file" && git commit -m "test commit" &>/dev/null
 


### PR DESCRIPTION
Previously, CTF was taking products only from `prodtype`. That was wrong as it ignored implicit "all products".

Now, with https://github.com/ComplianceAsCode/content/pull/11378 prodtype removal, all rules must be part of some profile (at least the `default.profile`) to get to benchmark. And to get to profile, they might get there via controls (that was ignored as well by CTF).

This PR adds support for searching rules in control files (works with control_dirs as well) and changes the prodtype search to new approach - products are determined based on used profiles.

Test changes come from https://github.com/ComplianceAsCode/content-test-filtering/pull/47

For testing, you can for example try:
```
$ python3 content_test_filtering.py pr --verbose --repository /home/mlysonek/SCAP/content 11501
```
to check that ocp4 product is selected (the rule introduced in this PR is only in controls file). (related to https://github.com/ComplianceAsCode/content/pull/11501#issuecomment-1916764237)